### PR TITLE
Update nokia5110.h

### DIFF
--- a/src/nokia5110.h
+++ b/src/nokia5110.h
@@ -12,8 +12,9 @@
 #define BLACK       1
 
 #include <Arduino.h>
+#include <avr/pgmspace.h> 
 
-static const byte ASCII[]  =
+static const byte ASCII[] PROGMEM =
 {
 0x00, 0x00, 0x00, 0x00, 0x00, // 20  
 0x00, 0x00, 0x5f, 0x00, 0x00, // 21 !


### PR DESCRIPTION
Corrigido: usando PROGMEM pra mover a tabela ASCII pra memória flash. 
Alerto que ao usar o driver do LED RGB junto com esse, dá conflito por conta do #define WHITE